### PR TITLE
Support getting latest server version when building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,13 @@ RUN apt update && \
 
 # build arguments
 ARG MCPORT
-ARG INSTALLERURL
+ARG VERSION
 ARG MCUSER
 ARG MCGROUP
 ENV MCUSER=${MCUSER:-1132}
 ENV MCGROUP=${MCGROUP:-1132}
 ENV MCPORT=${MCPORT:-19132}
-ENV INSTALLERURL=${INSTALLERURL:-"https://minecraft.azureedge.net/bin-linux/bedrock-server-1.13.1.5.zip"}
+ENV VERSION=${VERSION:-"latest"}
 
 # setup environment
 ENV container=docker
@@ -27,15 +27,24 @@ ENV PATH $PATH:${MCSERVERFOLDER}
 # open the server port
 EXPOSE $MCPORT
 
-# install minecraft
-RUN curl $INSTALLERURL --output mc.zip && \
-  unzip mc.zip -d $MCSERVERFOLDER && \
-  rm mc.zip && \
-  mkdir $MCSERVERFOLDER/default $MCVOLUME && \
-  chown -Rf $MCUSER:$MCGROUP $MCSERVERFOLDER $MCVOLUME && \
-  chmod -Rf g=u $MCSERVERFOLDER $MCVOLUME && \
-  rm ${MCSERVERFOLDER}/server.properties && \
-  for i in permissions.json whitelist.json behavior_packs definitions resource_packs structures;do mv $MCSERVERFOLDER/$i $MCSERVERFOLDER/default/$i;done
+# Install minecraft
+RUN if [ "$VERSION" = "latest" ] ; then \
+        LATEST_VERSION=$( \
+            curl -v --silent  https://www.minecraft.net/en-us/download/server/bedrock/ 2>&1 | \
+            grep -o 'https://minecraft.azureedge.net/bin-linux/[^"]*' | \
+            sed 's#.*/bedrock-server-##' | sed 's/.zip//') && \
+        export VERSION=$LATEST_VERSION && \
+        echo "Setting VERSION to $LATEST_VERSION" ; \
+    else echo "Using VERSION of $VERSION"; \
+    fi && \
+    curl https://minecraft.azureedge.net/bin-linux/bedrock-server-${VERSION}.zip --output mc.zip && \
+    unzip mc.zip -d $MCSERVERFOLDER && \
+    rm mc.zip && \
+    mkdir $MCSERVERFOLDER/default $MCVOLUME && \
+    chown -Rf $MCUSER:$MCGROUP $MCSERVERFOLDER $MCVOLUME && \
+    chmod -Rf g=u $MCSERVERFOLDER $MCVOLUME && \
+    rm ${MCSERVERFOLDER}/server.properties && \
+    for i in permissions.json whitelist.json behavior_packs definitions resource_packs structures;do mv $MCSERVERFOLDER/$i $MCSERVERFOLDER/default/$i;done
 
 # create folder for minecraft resources
 VOLUME $MCVOLUME

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ If no custom `server.properties` file is found, a default `server.properties` fi
 
 ### MCPROP_ Environment variables
 
-Environment variables may be passed through the command line or set in the `docker-compose.yml` file.  For instance, to change the gamemode to 1 over the CLI, one would set the `MCPROP_GAMEMODE` environment variable to `1`.
+Environment variables may be passed through the command line or set in the `docker-compose.yml` file. For instance, to change the gamemode to 1 over the CLI, one would set the `MCPROP_GAMEMODE` environment variable to `1`.
 
 ```
 docker run -e MCPROP_GAMEMODE=1 -e WORLD=world -v /path/to/mcdata:/mcdata -dit --name="minecraft" --network="host" karlrees/docker_bedrockserver
@@ -240,6 +240,11 @@ docker run -e MCPROP_GAMEMODE=1 -e WORLD=world -v /path/to/mcdata:/mcdata -dit -
 The `docker-compose.yml` gives some examples of passing `MCPROP_` environment variables through it.
 
 Note that `level-name` is a special property that is set by the `WORLD` environment variable, as opposed to `MCPROP_LEVEL-NAME`.
+
+
+## Version Environment variable
+
+A specific version of the bedrock server may be specified through the command line or set in the `docker-compose.yml` file by using the the `VERSION` variable. It defaults to `latest` which extracts the latest available version from the minecraft.net download page, but can also be set to a specific version string such as `1.13.3.0`.
 
 ## Custom permissions / whitelist / resource files and folders
 

--- a/README.md
+++ b/README.md
@@ -241,11 +241,6 @@ The `docker-compose.yml` gives some examples of passing `MCPROP_` environment va
 
 Note that `level-name` is a special property that is set by the `WORLD` environment variable, as opposed to `MCPROP_LEVEL-NAME`.
 
-
-## Version Environment variable
-
-A specific version of the bedrock server may be specified through the command line or set in the `docker-compose.yml` file by using the the `VERSION` variable. It defaults to `latest` which extracts the latest available version from the minecraft.net download page, but can also be set to a specific version string such as `1.13.3.0`.
-
 ## Custom permissions / whitelist / resource files and folders
 
 You can change your `permissions.json` file, `whitelist.json` file, `resource` directories, and so forth, by mounting the `/mcdata` folder to an external folder and making changes from there.  These are all linked to the appropriate locations on the server when the container is started.

--- a/templates/.env
+++ b/templates/.env
@@ -16,10 +16,10 @@
 
 
 #--------------------------------------------------
-# installer URL
+# Bedrock version
 #--------------------------------------------------
 
-# INSTALLERURL=https://minecraft.azureedge.net/bin-linux/bedrock-server-1.13.1.5.zip
+# VERSION=latest
 
 
 #--------------------------------------------------

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -12,7 +12,7 @@ x-mcserver-common:
   build: 
    context: .
    args:
-    INSTALLERURL: ${INSTALLERURL:-}
+    VERSION: ${VERSION:-}
     MCUSER: ${MCUSER:-}
     MCGROUP: ${MCGROUP:-}
     MCPORT: ${MCPORT:-}
@@ -57,6 +57,7 @@ services:
    #MCPROP_DIFFICULTY: 1           # 0 is peaceful, 1 is easy, 2 is normal, 3 is hard
    #MCPROP_ALLOW-CHEATS: "false"
    #MCPROP_LEVEL-SEED: "myseed1"   # only used if world does not yet exist
+   #VERSION: "latest"              # or a version string like "1.13.3.0"
   container_name: minecraft1
   networks: 
    default:
@@ -80,6 +81,7 @@ services:
    #MCPROP_DIFFICULTY: 1         # 0 is peaceful, 1 is easy, 2 is normal, 3 is hard
    #MCPROP_ALLOW-CHEATS: "false"
    #MCPROP_LEVEL-SEED: "myseed2"  # only used if world does not yet exist
+   #VERSION: "1.13.3.0"              # a version string like "1.13.3.0" or "latest" (default)
   container_name: minecraft2
   networks: 
    default:


### PR DESCRIPTION
This PR replaces the INSTALLERURL build argument with a VERSION argument and defaults to getting the latest version by parsing https://www.minecraft.net/en-us/download/server/bedrock/

What I would really like to support is the possibility to specify the version when running the container. That can be done by moving downloading and installing of the server to the .sh file, but I didn't have the time to finalize it now.