### PR TITLE
Bash for loop breaks on whitespace. Defined IFS for newline only.

### DIFF
--- a/resource/runbedrockserver.sh
+++ b/resource/runbedrockserver.sh
@@ -85,6 +85,8 @@ else
   # Examples
   #  - MCPROP_ALLOW_CHEATS=true
   #    allow-cheats=true
+  SAVEIFS="$IFS"
+  IFS=$'\n'
   for P in `printenv | grep '^MCPROP_'`
   do
     PROP_NAME=${P%%=*}
@@ -95,6 +97,7 @@ else
     echo -e "\t${PROP_NAME}=${PROP_VALUE}"
     echo "${PROP_NAME}=${PROP_VALUE}" >> ${MCSERVERFOLDER}/server.properties
   done
+  IFS="$SAVEIFS"
 fi
 
 # Link/create files


### PR DESCRIPTION
In docker-compse.yml:

    MCPROP_SERVER-NAME: "Multiple Villages"

but the result in server.properties:

    server-name=Multiple
    villages=Villages

Changing the IFS for the loop in `runbedrockserver.sh` fixes this.